### PR TITLE
Grammar 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ To clean up the build artifacts:
 
     ./gradlew clean
 
+# Generating the Javascript Parser Files
+
+By default, this project generates Java classes for parsing SHR text files.  This project can also generate Javascript classes and functions for parsing SHR text.  To create the Javascript parsers, execute the following command from within this directory:
+
+    ./gradlew generateAntlrJSGrammarSource
+
+This will generate the javascript into the _build/javascript/parsers_ folder.  To generate it into a different location use the `shr.js.parsers.dir` project property, as demonstrated below:
+
+    ./gradlew -Pshr.js.parsers.dir=../shr-text-import/lib/parsers generateAntlrJSGrammarSource
+
+
 # Parsing SHR Text Files
 
 The `ParseTool` application is a simple tool that parses an SHR file or a folder of SHR files.  The `ParseTool` will print out all syntactical errors where files don't conform to the ANLTR SHR specification.  This is useful during the development of SHR text files to ensure they are syntactically valid.  It does _not_, however, ensure correctness of references between elements, valid valuesets or codes, etc.

--- a/src/main/antlr/SHRLexer.g4
+++ b/src/main/antlr/SHRLexer.g4
@@ -25,10 +25,13 @@ KW_REF:             'ref';
 KW_OR:              'or';
 KW_WITH:            'with';
 KW_IS:              'is';
+KW_IS_TYPE:         'is type';
+KW_VALUE_IS_TYPE:   'value is type';
 KW_INCLUDES:        'includes';
 KW_TRUE:            'true';
 KW_FALSE:           'false';
 KW_TBD:             'TBD';
+KW_TBD_CODE:        'TBD#TBD';
 
 // KEYWORDS for FHIR Primitives
 KW_BOOLEAN:         'boolean';

--- a/src/main/antlr/SHRLexer.g4
+++ b/src/main/antlr/SHRLexer.g4
@@ -7,19 +7,23 @@ KW_PATH:            'Path:';
 KW_VOCABULARY:      'Vocabulary:';
 KW_ELEMENT:         'Element:';
 KW_ENTRY_ELEMENT:   'EntryElement:';
-KW_BASED_ON:        'BasedOn:';
+KW_BASED_ON:        'Based on:';
 KW_VALUE:           'Value:';
 KW_VALUESET_DEFINITIONS: 'ValueSetDefinitions:';
 KW_VALUESET:        'ValueSet:';
 KW_INCLUDES_CODES_FROM: 'Includes codes from';
 KW_INCLUDES_CODES_DESCENDING_FROM: 'Includes codes descending from';
 KW_AND_NOT_DESCENDING_FROM: 'and not descending from';
+KW_MAP:             'Map:';
+KW_TARGET:          'Target:';
+KW_MAPS_TO:         'maps to';
 KW_CONCEPT:         'Concept:';
 KW_DESCRIPTION:     'Description:';
 KW_REF:             'ref';
 KW_OR:              'or';
 KW_WITH:            'with';
 KW_IS:              'is';
+KW_INCLUDES:        'includes';
 KW_TBD:             'TBD';
 
 // KEYWORDS for FHIR Primitives
@@ -52,16 +56,20 @@ COMMA:              ',';
 STAR:               '*';
 OPEN_PAREN:         '(';
 CLOSE_PAREN:        ')';
+OPEN_BRACKET:       '[';
+CLOSE_BRACKET:      ']';
+COLON:              ':';
 RANGE:              '..';
 
 // PATTERNS
 URL:                [a-z]+ '://' [a-zA-Z][0-9a-zA-Z_%#=\\?\\-\\.\\/]*;
 PATH_URL:           [A-Z][A-Z0-9]* '/' [0-9a-zA-Z][0-9a-zA-Z_%#=\\?\\-\\.\\/]*;
 URN_OID:            'urn:oid:' [0-2]'.'[0-9]+('.'[0-9]+)*;
+URN:                'urn' (':'[0-9a-zA-Z\\.]+)+;
 CODE:               '#' [0-9a-zA-z\\-]+;
 WHOLE_NUMBER:       [0-9]+;
-ALL_CAPS:           [A-Z][A-Z0-9]*;
-UPPER_WORD:         [A-Z][0-9a-zA-Z\\-]*;
+ALL_CAPS:           [A-Z][A-Z0-9_]*;
+UPPER_WORD:         [A-Z][0-9a-zA-Z\\-_]*;
 LOWER_WORD:         [a-z][0-9a-zA-Z\\-]*;
 DOT_SEPARATED_LW:   [a-z][0-9a-zA-Z\\-]* ('.' [a-z][0-9a-zA-z\\-]*)+;
 DOT_SEPARATED_UW:   [a-z][0-9a-zA-Z\\-]* ('.' [a-z][0-9a-zA-z\\-]*)* ('.' [A-Z][0-9a-zA-z\\-]*);

--- a/src/main/antlr/SHRLexer.g4
+++ b/src/main/antlr/SHRLexer.g4
@@ -1,20 +1,22 @@
 lexer grammar SHRLexer;
 
 // KEYWORDS for SHR
-KW_DATA_DEFINITIONS:'DataDefinitions:';
+KW_GRAMMAR:         'Grammar:';
+KW_G_DATA_ELEMENT:  'DataElement';
+KW_G_VALUE_SET:     'ValueSet';
+KW_G_MAP:           'Map';
+KW_NAMESPACE:       'Namespace:';
 KW_USES:            'Uses:';
 KW_PATH:            'Path:';
-KW_VOCABULARY:      'Vocabulary:';
+KW_VOCABULARY:      'CodeSystem:'; // Don't rename token for now (it will cause merge conflicts w/ other work)
 KW_ELEMENT:         'Element:';
 KW_ENTRY_ELEMENT:   'EntryElement:';
 KW_BASED_ON:        'Based on:';
 KW_VALUE:           'Value:';
-KW_VALUESET_DEFINITIONS: 'ValueSetDefinitions:';
 KW_VALUESET:        'ValueSet:';
 KW_INCLUDES_CODES_FROM: 'Includes codes from';
 KW_INCLUDES_CODES_DESCENDING_FROM: 'Includes codes descending from';
 KW_AND_NOT_DESCENDING_FROM: 'and not descending from';
-KW_MAP:             'Map:';
 KW_TARGET:          'Target:';
 KW_MAPS_TO:         'maps to';
 KW_CONCEPT:         'Concept:';
@@ -24,6 +26,8 @@ KW_OR:              'or';
 KW_WITH:            'with';
 KW_IS:              'is';
 KW_INCLUDES:        'includes';
+KW_TRUE:            'true';
+KW_FALSE:           'false';
 KW_TBD:             'TBD';
 
 // KEYWORDS for FHIR Primitives

--- a/src/main/antlr/SHRParser.g4
+++ b/src/main/antlr/SHRParser.g4
@@ -93,13 +93,11 @@ fullyQualifiedName: DOT_SEPARATED_UW;
 simpleOrFQName:     simpleName | fullyQualifiedName;
 ref:                KW_REF OPEN_PAREN simpleOrFQName CLOSE_PAREN;
 code:               CODE STRING?;
-fullyQualifiedCode: ALL_CAPS code;
-codeOrFQCode:       fullyQualifiedCode | code | tbd;
+fullyQualifiedCode: (ALL_CAPS code) | tbdCode;
+codeOrFQCode:       fullyQualifiedCode | code;
 codeFromVS:         (KW_CODE_FROM | KW_CODING_FROM) valueset;
 
 //elementWithConstraint
-
-
 
 elementWithConstraint:      (simpleOrFQName | elementPath | primitive) elementConstraint?;
 elementPath:                simpleOrFQName (((DOT simpleName)+ (DOT primitive)?) | ((DOT simpleName)* DOT primitive));
@@ -108,7 +106,7 @@ elementCodeVSConstraint:    KW_WITH codeFromVS;
 elementCodeValueConstraint: KW_IS codeOrFQCode;
 elementIncludesCodeValueConstraint: (KW_INCLUDES codeOrFQCode)+;
 elementBooleanConstraint:   KW_IS (KW_TRUE | KW_FALSE);
-elementTypeConstraint:      KW_IS (simpleOrFQName | tbd);
+elementTypeConstraint:      (KW_IS_TYPE | KW_VALUE_IS_TYPE) (simpleOrFQName | tbd);
 elementWithUnitsConstraint: KW_WITH KW_UNITS fullyQualifiedCode;
 valueset:           URL | PATH_URL | URN_OID | simpleName | tbd;
 primitive:          KW_BOOLEAN | KW_INTEGER | KW_STRING | KW_DECIMAL | KW_URI | KW_BASE64_BINARY | KW_INSTANT | KW_DATE
@@ -116,3 +114,4 @@ primitive:          KW_BOOLEAN | KW_INTEGER | KW_STRING | KW_DECIMAL | KW_URI | 
                     | KW_POSITIVE_INT;
 count:              WHOLE_NUMBER RANGE (WHOLE_NUMBER | STAR);
 tbd:                KW_TBD STRING?;
+tbdCode:            KW_TBD_CODE STRING?;

--- a/src/main/antlr/SHRParser.g4
+++ b/src/main/antlr/SHRParser.g4
@@ -4,10 +4,10 @@ options { tokenVocab=SHRLexer; }
 
 shr:                dataDefsDoc | valuesetDefsDoc | mappingsDoc /* | contentProfiles*/;
 
-// DATA DEFINITIONS (Vocabularies, Entries, Elements)
+// DATA DEFINITIONS (Grammar: DataElement)
 
-dataDefsDoc:        dataDefsHeader usesStatement? pathDefs? vocabularyDefs? dataDefs;
-dataDefsHeader:     KW_DATA_DEFINITIONS namespace;
+dataDefsDoc:        dataDefsHeader descriptionProp? usesStatement? pathDefs? vocabularyDefs? dataDefs;
+dataDefsHeader:     KW_GRAMMAR KW_G_DATA_ELEMENT version KW_NAMESPACE namespace;
 
 usesStatement:      KW_USES namespace (COMMA namespace)*;
 
@@ -30,7 +30,7 @@ entryHeader:        KW_ENTRY_ELEMENT simpleName;
 elementProps:       elementProp+;
 elementProp:        basedOnProp | conceptProp | descriptionProp;
 
-values:             (value field*) | (value? field+);
+values:             value? field*;
 
 value:              KW_VALUE (uncountedValue | countedValue);
 uncountedValue:     (valueType (KW_OR valueType)*) | (OPEN_PAREN valueType (KW_OR valueType)* CLOSE_PAREN);
@@ -38,7 +38,7 @@ countedValue:       count valueType | count OPEN_PAREN valueType (KW_OR valueTyp
 valueType:          simpleOrFQName | ref | primitive | codeFromVS | elementWithConstraint | tbd;
 
 field:              countedField (KW_OR countedField)*;
-countedField:       count (fieldType | OPEN_PAREN fieldType (KW_OR fieldType)* CLOSE_PAREN);
+countedField:       count? (fieldType | OPEN_PAREN fieldType (KW_OR fieldType)* CLOSE_PAREN);
 fieldType:          simpleOrFQName | ref | elementWithConstraint | tbd;
 
 basedOnProp:        KW_BASED_ON (simpleOrFQName | tbd);
@@ -46,10 +46,10 @@ conceptProp:        KW_CONCEPT (tbd | concepts);
 concepts:           fullyQualifiedCode (COMMA fullyQualifiedCode)*;
 descriptionProp:    KW_DESCRIPTION STRING;
 
-// VALUESET DEFINITIONS
+// VALUESET DEFINITIONS (Grammar: ValueSet)
 
 valuesetDefsDoc:    valuesetDefsHeader usesStatement? pathDefs? vocabularyDefs? valuesetDefs;
-valuesetDefsHeader: KW_VALUESET_DEFINITIONS namespace;
+valuesetDefsHeader: KW_GRAMMAR KW_G_VALUE_SET version KW_NAMESPACE  namespace;
 
 valuesetDefs:           valuesetDef*;
 valuesetDef:            valuesetHeader valuesetProps? valuesetValues?;
@@ -63,10 +63,10 @@ valuesetFrom:           KW_INCLUDES_CODES_FROM fullyQualifiedCode;
 valuesetProps:      valuesetProp+;
 valuesetProp:       conceptProp | descriptionProp;
 
-// MAPPINGS
+// MAPPINGS (Grammar: Map)
 
 mappingsDoc:        mappingsHeader targetStatement mappingDefs;
-mappingsHeader:     KW_MAP namespace;
+mappingsHeader:     KW_GRAMMAR KW_G_MAP version KW_NAMESPACE  namespace;
 targetStatement:    KW_TARGET simpleName;
 
 mappingDefs:        mappingDef*;
@@ -86,6 +86,7 @@ cardMapping:        targetPart KW_IS count;
 
 // COMMON BITS
 
+version:            WHOLE_NUMBER DOT WHOLE_NUMBER;
 namespace:          LOWER_WORD | DOT_SEPARATED_LW;
 simpleName:         UPPER_WORD | ALL_CAPS;
 fullyQualifiedName: DOT_SEPARATED_UW;
@@ -93,12 +94,20 @@ simpleOrFQName:     simpleName | fullyQualifiedName;
 ref:                KW_REF OPEN_PAREN simpleOrFQName CLOSE_PAREN;
 code:               CODE STRING?;
 fullyQualifiedCode: ALL_CAPS code;
+codeOrFQCode:       fullyQualifiedCode | code | tbd;
 codeFromVS:         (KW_CODE_FROM | KW_CODING_FROM) valueset;
-elementWithConstraint:      simpleOrFQName (DOT simpleName)* elementConstraint;
-elementConstraint:          elementCodeVSConstraint | elementCodeValueConstraint | elementIncludesCodeValueConstraint | elementTypeConstraint | elementWithUnitsConstraint;
+
+//elementWithConstraint
+
+
+
+elementWithConstraint:      (simpleOrFQName | elementPath | primitive) elementConstraint?;
+elementPath:                simpleOrFQName (((DOT simpleName)+ (DOT primitive)?) | ((DOT simpleName)* DOT primitive));
+elementConstraint:          elementCodeVSConstraint | elementCodeValueConstraint | elementIncludesCodeValueConstraint | elementBooleanConstraint | elementTypeConstraint | /*elementIncludesTypeConstraint |*/ elementWithUnitsConstraint;
 elementCodeVSConstraint:    KW_WITH codeFromVS;
-elementCodeValueConstraint: KW_IS (fullyQualifiedCode | tbd);
-elementIncludesCodeValueConstraint: KW_INCLUDES fullyQualifiedCode;
+elementCodeValueConstraint: KW_IS codeOrFQCode;
+elementIncludesCodeValueConstraint: (KW_INCLUDES codeOrFQCode)+;
+elementBooleanConstraint:   KW_IS (KW_TRUE | KW_FALSE);
 elementTypeConstraint:      KW_IS (simpleOrFQName | tbd);
 elementWithUnitsConstraint: KW_WITH KW_UNITS fullyQualifiedCode;
 valueset:           URL | PATH_URL | URN_OID | simpleName | tbd;


### PR DESCRIPTION
Updates the grammar to support
- the new mappings format (for mapping to FHIR or other models)
- support for declaring grammar version in files
- Namespace keyword
- using TBD as a placeholder in more places
- keyword change from "BasedOn:" to "Based on:"
- allow elements that don't have value or fields
- support vocabularies that are non-oid URNs
- "includes" code constraint
- "is type" and "value is type" constraints
- boolean constraints (e.g., Foo.boolean is true)
- allow constraints on primitives
- allow code constraints to use code without system
- don't require cardinalities (for constraints)
