### PR TITLE
Grammar 4.1

### DIFF
--- a/src/main/antlr/SHRLexer.g4
+++ b/src/main/antlr/SHRLexer.g4
@@ -52,6 +52,7 @@ KW_POSITIVE_INT:    'positiveInt';
 // KEYWORDS for types w/ qualifiers
 KW_CODE_FROM:       'code from';
 KW_CODING_FROM:     'Coding from';
+KW_CODEABLECONCEPT_FROM: 'CodeableConcept from';
 KW_UNITS:           'units';
 
 // KEYWORDS for mapping

--- a/src/main/antlr/SHRLexer.g4
+++ b/src/main/antlr/SHRLexer.g4
@@ -79,7 +79,7 @@ URL:                [a-z]+ '://' [a-zA-Z][0-9a-zA-Z_%#=\\?\\-\\.\\/]*;
 PATH_URL:           [A-Z][A-Z0-9]* '/' [0-9a-zA-Z][0-9a-zA-Z_%#=\\?\\-\\.\\/]*;
 URN_OID:            'urn:oid:' [0-2]'.'[0-9]+('.'[0-9]+)*;
 URN:                'urn' (':'[0-9a-zA-Z\\.]+)+;
-CODE:               '#' [0-9a-zA-z\\-]+;
+CODE:               '#' ~[, \r\t\n]+;
 WHOLE_NUMBER:       [0-9]+;
 ALL_CAPS:           [A-Z][A-Z0-9_]*;
 UPPER_WORD:         [A-Z][0-9a-zA-Z\\-_]*;

--- a/src/main/antlr/SHRLexer.g4
+++ b/src/main/antlr/SHRLexer.g4
@@ -17,8 +17,6 @@ KW_VALUESET:        'ValueSet:';
 KW_INCLUDES_CODES_FROM: 'Includes codes from';
 KW_INCLUDES_CODES_DESCENDING_FROM: 'Includes codes descending from';
 KW_AND_NOT_DESCENDING_FROM: 'and not descending from';
-KW_TARGET:          'Target:';
-KW_MAPS_TO:         'maps to';
 KW_CONCEPT:         'Concept:';
 KW_DESCRIPTION:     'Description:';
 KW_REF:             'ref';
@@ -52,9 +50,15 @@ KW_UNSIGNED_INT:    'unsignedInt';
 KW_POSITIVE_INT:    'positiveInt';
 
 // KEYWORDS for types w/ qualifiers
-KW_CODE_FROM:   'code from';
-KW_CODING_FROM: 'Coding from';
-KW_UNITS:       'units';
+KW_CODE_FROM:       'code from';
+KW_CODING_FROM:     'Coding from';
+KW_UNITS:           'units';
+
+// KEYWORDS for mapping
+KW_TARGET:          'Target:';
+KW_MAPS_TO:         'maps to' -> pushMode(MAPPING_TARGET);
+KW_CONSTRAIN:       'constrain' -> pushMode(MAPPING_TARGET);
+KW_TO:              'to';
 
 // SYMBOLS
 DOT:                '.';
@@ -83,7 +87,11 @@ DOT_SEPARATED_UW:   [a-z][0-9a-zA-Z\\-]* ('.' [a-z][0-9a-zA-z\\-]*)* ('.' [A-Z][
 STRING:             '"' (~[\\"])* '"';
 
 // THINGS WE GENERALLY IGNORE
-WS:                 (' ' | '\r' | '\t') -> channel(HIDDEN);
-NEWLINE:            ('\n') -> channel(HIDDEN);
+WS:                 [ \r\t] -> channel(HIDDEN);
+NEWLINE:            '\n' -> channel(HIDDEN);
 COMMENT:            '/*' .*? '*/' -> skip;
 LINE_COMMENT:       '//' ~[\r\n]* -> skip;
+
+mode MAPPING_TARGET;
+TARGET_PHRASE: ~[ \r\t\n]* ~[ \r\t\n:] -> popMode;
+WS2: [ \r\t\n]+ -> channel(HIDDEN);

--- a/src/main/antlr/SHRLexer.g4
+++ b/src/main/antlr/SHRLexer.g4
@@ -48,6 +48,7 @@ KW_ID:              'id';
 KW_MARKDOWN:        'markdown';
 KW_UNSIGNED_INT:    'unsignedInt';
 KW_POSITIVE_INT:    'positiveInt';
+KW_XHTML:           'xhtml';
 
 // KEYWORDS for types w/ qualifiers
 KW_CODE_FROM:       'code from';

--- a/src/main/antlr/SHRParser.g4
+++ b/src/main/antlr/SHRParser.g4
@@ -70,17 +70,15 @@ mappingsHeader:     KW_GRAMMAR KW_G_MAP version KW_NAMESPACE  namespace;
 targetStatement:    KW_TARGET simpleName;
 
 mappingDefs:        mappingDef*;
-mappingDef:         mappingDefHeader fieldMapping*;
-mappingDefHeader:   simpleName (KW_MAPS_TO simpleName)? COLON;
+mappingDef:         mappingDefHeader mappingRule*;
+mappingDefHeader:   simpleName (KW_MAPS_TO TARGET_PHRASE)? COLON;
 
-fieldMapping:       fieldToFieldMapping | urlMapping | cardMapping;
-fieldToFieldMapping:source KW_MAPS_TO target;
-source:             sourcePart (DOT sourcePart)* (OPEN_BRACKET source CLOSE_BRACKET)?;
-sourcePart:         simpleOrFQName | primitive | tbd;
-target:             targetPart (DOT targetPart)* (OPEN_BRACKET target CLOSE_BRACKET)?;
-targetPart:         LOWER_WORD | DOT_SEPARATED_LW /*yuck*/ | UPPER_WORD | ALL_CAPS | primitive;
-urlMapping:         source KW_MAPS_TO URL;
-cardMapping:        targetPart KW_IS count;
+mappingRule:        fieldMapping | cardMapping;
+fieldMapping:       source KW_MAPS_TO TARGET_PHRASE;
+source:             sourcePart (DOT sourcePart)*;
+sourcePart:         sourceWord (OPEN_BRACKET sourceWord CLOSE_BRACKET)*;
+sourceWord:         simpleOrFQName | primitive | tbd;
+cardMapping:        KW_CONSTRAIN TARGET_PHRASE KW_TO count;
 
 // CONTENT PROFILES: TODO -- May Be a Separate Grammar
 

--- a/src/main/antlr/SHRParser.g4
+++ b/src/main/antlr/SHRParser.g4
@@ -109,7 +109,7 @@ elementWithUnitsConstraint: KW_WITH KW_UNITS fullyQualifiedCode;
 valueset:           URL | PATH_URL | URN_OID | simpleName | tbd;
 primitive:          KW_BOOLEAN | KW_INTEGER | KW_STRING | KW_DECIMAL | KW_URI | KW_BASE64_BINARY | KW_INSTANT | KW_DATE
                     | KW_DATE_TIME | KW_TIME | KW_CODE | KW_OID | KW_ID | KW_MARKDOWN | KW_UNSIGNED_INT
-                    | KW_POSITIVE_INT;
+                    | KW_POSITIVE_INT | KW_XHTML;
 count:              WHOLE_NUMBER RANGE (WHOLE_NUMBER | STAR);
 tbd:                KW_TBD STRING?;
 tbdCode:            KW_TBD_CODE STRING?;

--- a/src/main/antlr/SHRParser.g4
+++ b/src/main/antlr/SHRParser.g4
@@ -93,7 +93,7 @@ ref:                KW_REF OPEN_PAREN simpleOrFQName CLOSE_PAREN;
 code:               CODE STRING?;
 fullyQualifiedCode: (ALL_CAPS code) | tbdCode;
 codeOrFQCode:       fullyQualifiedCode | code;
-codeFromVS:         (KW_CODE_FROM | KW_CODING_FROM) valueset;
+codeFromVS:         (KW_CODE_FROM | KW_CODING_FROM | KW_CODEABLECONCEPT_FROM) valueset;
 
 //elementWithConstraint
 


### PR DESCRIPTION
Grammar 4.1 contains the following changes:
- Better support for arbitrary targets in mapping grammars (by switching lexer modes)
- Support for CodeableConcept in code constraints
- Support for xhtml primitive (used in Narrative)
- Support for nearly any character in code literals (excluding `,`)