### PR TITLE
Remove "with code" type constructs from grammar

### DIFF
--- a/src/main/antlr/SHRDataElementParser.g4
+++ b/src/main/antlr/SHRDataElementParser.g4
@@ -30,7 +30,7 @@ elementProp:        basedOnProp | conceptProp | descriptionProp;
 values:             value? field*;
 
 value:              KW_VALUE count? OPEN_PAREN? valueType (KW_OR valueType)* CLOSE_PAREN?; // TODO: Remove PAREN (here for backwards compatibility now)
-valueType:          simpleOrFQName | ref | primitive | codeFromVS | elementWithConstraint | tbd;
+valueType:          simpleOrFQName | ref | primitive | elementWithConstraint | tbd;
 
 field:              count? OPEN_PAREN? fieldType (KW_OR fieldType)* CLOSE_PAREN?; // TODO: Remove PAREN (here for backwards compatibility now)
 fieldType:          simpleOrFQName | ref | elementWithConstraint | tbd;
@@ -51,7 +51,6 @@ ref:                KW_REF OPEN_PAREN simpleOrFQName CLOSE_PAREN;
 code:               CODE STRING?;
 fullyQualifiedCode: (ALL_CAPS code) | tbdCode;
 codeOrFQCode:       fullyQualifiedCode | code;
-codeFromVS:         (KW_CODE | simpleOrFQName) bindingInfix? KW_FROM valueset KW_IF_COVERED?;
 bindingInfix:       KW_MUST_BE | KW_SHOULD_BE | KW_COULD_BE;
 
 //elementWithConstraint
@@ -59,7 +58,8 @@ bindingInfix:       KW_MUST_BE | KW_SHOULD_BE | KW_COULD_BE;
 elementWithConstraint:      (simpleOrFQName | elementPath | primitive) elementConstraint?;
 elementPath:                simpleOrFQName (((DOT simpleName)+ (DOT primitive)?) | ((DOT simpleName)* DOT primitive));
 elementConstraint:          elementCodeVSConstraint | elementCodeValueConstraint | elementIncludesCodeValueConstraint | elementBooleanConstraint | elementTypeConstraint | /*elementIncludesTypeConstraint |*/ elementWithUnitsConstraint;
-elementCodeVSConstraint:    KW_WITH codeFromVS;
+legacyWithCode:             KW_WITH (KW_CODE | simpleOrFQName); // Just here for backwards compatibility until definitions are updated
+elementCodeVSConstraint:    legacyWithCode? bindingInfix? KW_FROM valueset KW_IF_COVERED?;
 elementCodeValueConstraint: KW_IS codeOrFQCode;
 elementIncludesCodeValueConstraint: (KW_INCLUDES codeOrFQCode)+;
 elementBooleanConstraint:   KW_IS (KW_TRUE | KW_FALSE);


### PR DESCRIPTION
Instead of having to say "Foo with CodeableConcept from Bar", you can now say "Foo from Bar".  The expander will take care of the details regarding getting the constraint path right (and pointing to a code-ish thing).

For temporary backwards compatibility, I've left in an optional partial that will allow the "with code" type phrases, but the importer ignores them.