### PR TITLE
Fixes issue shr-cli#23: Crash when element name doesn't have leading Capitalization

### DIFF
--- a/src/main/antlr/SHRDataElementParser.g4
+++ b/src/main/antlr/SHRDataElementParser.g4
@@ -44,7 +44,7 @@ descriptionProp:    KW_DESCRIPTION STRING;
 
 version:            WHOLE_NUMBER DOT WHOLE_NUMBER;
 namespace:          LOWER_WORD | DOT_SEPARATED_LW;
-simpleName:         UPPER_WORD | ALL_CAPS;
+simpleName:         UPPER_WORD | ALL_CAPS | LOWER_WORD; //LOWER_WORD is not intended use, and will throw an error. However, this prevents compiler crash.
 fullyQualifiedName: DOT_SEPARATED_UW;
 simpleOrFQName:     simpleName | fullyQualifiedName;
 ref:                KW_REF OPEN_PAREN simpleOrFQName CLOSE_PAREN;


### PR DESCRIPTION
Adds 'support' for LOWER_WORD so compiler doesn't crash. However, in the listener it intentionally throws an error.

Solution to error: standardhealth/shr-cli#23