### PR TITLE
Support "value is type $primitive" for constraining choices

### DIFF
--- a/src/main/antlr/SHRDataElementParser.g4
+++ b/src/main/antlr/SHRDataElementParser.g4
@@ -52,7 +52,7 @@ code:               CODE STRING?;
 fullyQualifiedCode: (ALL_CAPS code) | tbdCode;
 codeOrFQCode:       fullyQualifiedCode | code;
 bindingInfix:       KW_MUST_BE | KW_SHOULD_BE | KW_COULD_BE;
-typeConstraint:     count (simpleOrFQName | ref | tbd);
+typeConstraint:     count (simpleOrFQName | ref | primitive | tbd);
 
 //elementWithConstraint
 
@@ -64,7 +64,7 @@ elementCodeVSConstraint:    legacyWithCode? bindingInfix? KW_FROM valueset KW_IF
 elementCodeValueConstraint: KW_IS codeOrFQCode;
 elementIncludesCodeValueConstraint: (KW_INCLUDES codeOrFQCode)+;
 elementBooleanConstraint:   KW_IS (KW_TRUE | KW_FALSE);
-elementTypeConstraint:      (KW_IS_TYPE | KW_VALUE_IS_TYPE) (simpleOrFQName | ref | tbd);
+elementTypeConstraint:      (KW_IS_TYPE | KW_VALUE_IS_TYPE) (simpleOrFQName | ref | primitive | tbd);
 elementIncludesTypeConstraint: (KW_INCLUDES typeConstraint)+;
 elementWithUnitsConstraint: KW_WITH KW_UNITS fullyQualifiedCode;
 valueset:           URL | PATH_URL | URN_OID | simpleName | tbd;


### PR DESCRIPTION
The "value is type" type constraint can also be used to constrain a choice to a subset.  In this case, the type you are constraining could be a primitive.  Prior to this fix, the parser choked if trying to constrain to a primitive.

Fixes #27.