### PR TITLE
Move filtering to content profile

### DIFF
--- a/src/main/antlr/SHRContentProfileLexer.g4
+++ b/src/main/antlr/SHRContentProfileLexer.g4
@@ -8,6 +8,7 @@ KW_G_CONTENT_PROFILE:  'ContentProfile';
 KW_NAMESPACE:       'Namespace:';
 KW_MUST_SUPPORT:    'MS';
 KW_NO_PROFILE:      'NP';
+KW_ALL_PRIMARY:     '*';
 
 // SYMBOLS
 DOT:                '.';

--- a/src/main/antlr/SHRContentProfileParser.g4
+++ b/src/main/antlr/SHRContentProfileParser.g4
@@ -8,7 +8,7 @@ doc:                docHeader contentsDefs;
 docHeader:          KW_GRAMMAR KW_G_CONTENT_PROFILE version;
 
 contentsDefs:       (namespaceHeader contentDefs)*;
-namespaceHeader:    KW_NAMESPACE namespace;
+namespaceHeader:    KW_NAMESPACE namespace (namespaceFlag)?;
 
 contentDefs:        contentDef*;
 contentDef:         (contentHeader cpRules) | (contentHeader headerFlags) | contentHeader;
@@ -22,6 +22,8 @@ flag:               KW_MUST_SUPPORT;
 
 headerFlags:        headerFlag+;
 headerFlag:         KW_NO_PROFILE;
+
+namespaceFlag:      KW_NO_PROFILE | KW_ALL_PRIMARY;
 
 // COMMON BITS
 

--- a/src/main/antlr/SHRContentProfileParser.g4
+++ b/src/main/antlr/SHRContentProfileParser.g4
@@ -11,7 +11,7 @@ contentsDefs:       (namespaceHeader contentDefs)*;
 namespaceHeader:    KW_NAMESPACE namespace;
 
 contentDefs:        contentDef*;
-contentDef:         (contentHeader cpRules) | (contentHeader headerFlags);
+contentDef:         (contentHeader cpRules) | (contentHeader headerFlags) | contentHeader;
 contentHeader:      simpleName COLON;
 
 cpRules:            cpRule*;

--- a/src/main/antlr/SHRContentProfileParser.g4
+++ b/src/main/antlr/SHRContentProfileParser.g4
@@ -8,7 +8,7 @@ doc:                docHeader contentsDefs;
 docHeader:          KW_GRAMMAR KW_G_CONTENT_PROFILE version;
 
 contentsDefs:       (namespaceHeader contentDefs)*;
-namespaceHeader:    KW_NAMESPACE namespace (namespaceFlag)?;
+namespaceHeader:    KW_NAMESPACE namespace namespaceFlag?;
 
 contentDefs:        contentDef*;
 contentDef:         (contentHeader cpRules) | (contentHeader headerFlags) | contentHeader;


### PR DESCRIPTION
Adds filtering and primary profile selection grammar to the content profile. Also adds the ability to specify no profile for an entire namespace, or to specify that all profiles in a given namespace are primary.
- Applying primary profile selection to namespace
    - `Namespace: obf *`
- Applying no profile selection to namespace
    - `Namespace: obf NP`
- Any mentioned entry/group is treated as being selected to make primary profile of, example:
    - `Observation:` 
    - Now observation will be a primary profile
- Applying a flag at the level of an individual entry overrides a namespace level flag
PR 1/5