### PR TITLE
Add grammar for SubsetConstraint

### DIFF
--- a/src/main/antlr/SHRDataElementParser.g4
+++ b/src/main/antlr/SHRDataElementParser.g4
@@ -63,6 +63,7 @@ fullyQualifiedCode: (ALL_CAPS code) | tbdCode;
 codeOrFQCode:       fullyQualifiedCode | code;
 bindingStrength:    KW_REQUIRED | KW_PREFERRED | KW_EXAMPLE| KW_EXTENSIBLE;
 typeConstraint:     (simpleOrFQName | primitive | tbd) count;
+subsetConstraint:   (simpleOrFQName | primitive | tbd);
 
 elementWithConstraint:      (specialWord | simpleOrFQName | elementBracketPath | primitive) (count | elementConstraint)?;
 //valueWithConstraint:      KW_VALUE elementConstraint?;
@@ -73,7 +74,7 @@ elementBracketPathFirstPart:    specialWord | simpleOrFQName;
 elementBracketPathSecondPart:   OPEN_BRACKET (simpleName | primitive) CLOSE_BRACKET;
 elementBracketPathThirdPart:    DOT simpleName elementBracketPathSecondPart*;
 elementBracketPath:             elementBracketPathFirstPart elementBracketPathSecondPart* elementBracketPathThirdPart*;
-elementConstraint:          elementCodeVSConstraint | elementCodeValueConstraint | elementIncludesCodeValueConstraint | elementBooleanConstraint | elementStringConstraint | elementIntegerConstraint | elementDecimalConstraint | elementTypeConstraint | elementIncludesTypeConstraint | elementUrlConstraint;
+elementConstraint:          elementCodeVSConstraint | elementCodeValueConstraint | elementIncludesCodeValueConstraint | elementBooleanConstraint | elementStringConstraint | elementIntegerConstraint | elementDecimalConstraint | elementTypeConstraint | elementSubsetConstraint | elementIncludesTypeConstraint | elementUrlConstraint;
 elementCodeVSConstraint:    KW_FROM valueset (OPEN_PAREN bindingStrength CLOSE_PAREN)?;
 elementCodeValueConstraint: EQUAL fullyQualifiedCode;
 elementIncludesCodeValueConstraint: (PLUS EQUAL fullyQualifiedCode)+;
@@ -82,6 +83,7 @@ elementStringConstraint:    EQUAL STRING; // Can also be applied to fix a URI
 elementIntegerConstraint:   EQUAL MINUS? WHOLE_NUMBER; // Can also be applied to fix a decimal value
 elementDecimalConstraint:   EQUAL MINUS? WHOLE_NUMBER DOT WHOLE_NUMBER? EXP?;
 elementTypeConstraint:      (KW_SUBSTITUTE | KW_ONLY) (simpleOrFQName | primitive | tbd);
+elementSubsetConstraint:    KW_ONLY (subsetConstraint) (KW_OR (subsetConstraint))+;
 elementUrlConstraint:       EQUAL URL;
 elementIncludesTypeConstraint: (KW_INCLUDES typeConstraint)+;
 valueset:           URL | PATH_URL | URN_OID | URN |simpleName | tbd;


### PR DESCRIPTION
Adds grammar for constraining a property to a choice of several types. An example of the supported syntax is given below.
```
Element: Elem1
Value: integer or string or uri or concept

Entry: Entr1
Property: Elem1 0..1
  Elem1 only integer or string // This is now supported
```
This PR is 1/7. These PRs impact:
* `shr-grammar`
* `shr-text-import` https://github.com/standardhealth/shr-text-import/pull/108
* `shr-models` https://github.com/standardhealth/shr-models/pull/47
* `shr-expand` https://github.com/standardhealth/shr-expand/pull/48
* `shr-fhir-export` https://github.com/standardhealth/shr-fhir-export/pull/161
* `shr-json-schema-export` https://github.com/standardhealth/shr-json-schema-export/pull/16
* `shr-json-javadoc` https://github.com/standardhealth/shr-json-javadoc/pull/29